### PR TITLE
ci: update metanorma workflows and add release manifest

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -2,7 +2,7 @@ name: generate
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -12,35 +12,10 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    container:
-      image: metanorma/metanorma:latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Cache Metanorma assets
-        uses: actions-mn/cache@v1
-
-      - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          agree-to-terms: true
-
-  deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  site:
+    uses: actions-mn/.github/.github/workflows/metanorma-generate.yml@v1
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths: ['sources/**', 'metanorma.yml', 'metanorma.release.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@v1
+    with:
+      default-visibility: private
+    secrets: inherit

--- a/metanorma.release.yml
+++ b/metanorma.release.yml
@@ -1,0 +1,1 @@
+documents:


### PR DESCRIPTION
Updates CI workflows to use shared reusable workflows from `actions-mn/.github`.

Changes:
- `generate.yml` now references `actions-mn/.github/.github/workflows/metanorma-generate.yml@v1`
- `release.yml` now references `actions-mn/.github/.github/workflows/metanorma-release.yml@v1`
- Sets `default-visibility: private` (safe-by-default)
- Adds `metanorma.release.yml` with document visibility rules