### PR TITLE
fix: reference release workflow by SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@v1
+    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@1e39548
     with:
       default-visibility: private
     secrets: inherit


### PR DESCRIPTION
Fixes GitHub Actions cache issue by referencing the reusable workflow by commit SHA.